### PR TITLE
fix skipif test for ccm algo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ modules/
 nbproject/
 run-tests.php
 *.net
+tmp-php.ini
+ltmain.sh.backup
+crypto-*.tgz

--- a/crypto.c
+++ b/crypto.c
@@ -80,6 +80,12 @@ PHP_MINIT_FUNCTION(crypto)
 	/* Init OpenSSL algorithms */
 	OpenSSL_add_all_algorithms();
 
+#if defined(EVP_CIPH_CCM_MODE) && OPENSSL_VERSION_NUMBER < 0x100020000
+	EVP_add_cipher(EVP_aes_128_ccm());
+	EVP_add_cipher(EVP_aes_192_ccm());
+	EVP_add_cipher(EVP_aes_256_ccm());
+#endif
+
 	PHP_MINIT(crypto_cipher)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(crypto_hash)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(crypto_base64)(INIT_FUNC_ARGS_PASSTHRU);

--- a/package.xml
+++ b/package.xml
@@ -104,6 +104,7 @@
     <file role="test" name="Cipher_encrypt_basic.phpt"/>
     <file role="test" name="Cipher_getAlgorithmName_basic.phpt"/>
     <file role="test" name="Cipher_getAlgorithms_basic.phpt"/>
+    <file role="test" name="Cipher_getAlgorithms_ccm.phpt"/>
     <file role="test" name="Cipher_getBlockSize_basic.phpt"/>
     <file role="test" name="Cipher_getIVLength_basic.phpt"/>
     <file role="test" name="Cipher_getKeyLength_basic.phpt"/>

--- a/tests/Cipher_getAlgorithms_ccm.phpt
+++ b/tests/Cipher_getAlgorithms_ccm.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Crypto\Cipher::getAlgorithms in CCM mode basic usage.
+--SKIPIF--
+<?php
+if (!Crypto\Cipher::hasMode(Crypto\Cipher::MODE_CCM))
+	die("Skip: CCM mode not defined (update OpenSSL version)");
+?>
+--FILE--
+<?php
+$algos = Crypto\cipher::getAlgorithms();
+foreach ($algos as $algo) {
+	if (substr($algo, -3) == 'ccm') {
+		echo "$algo\n";
+	}
+}
+?>
+Done
+--EXPECT--
+aes-128-ccm
+aes-192-ccm
+aes-256-ccm
+Done


### PR DESCRIPTION
When buildiung on Fedora <= 22 and RHEL (openssl 1.0.1), ccm algo are not available.

This simple fix allow to run build + test suite.

P.S. test suite ok on Fedora 23 with openssl 1.0.2