### PR TITLE
Fixed configure on Windows with OpenSSL 1.1.0+

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -5,7 +5,7 @@ ARG_WITH("crypto", "Crypto support", "no");
 
 if (PHP_CRYPTO != "no") {
 	if (ADD_EXTENSION_DEP('CRYPTO', 'OPENSSL')
-			&& CHECK_LIB("libeay32.lib", "crypto", PHP_CRYPTO)) {
+			&& (CHECK_LIB("libeay32.lib", "crypto", PHP_CRYPTO) || CHECK_LIB("libcrypto.lib", "crypto", PHP_CRYPTO))) {
 		AC_DEFINE("HAVE_CRYPTOLIB",1,"[Whether you want objective crypto binding]");
 		EXTENSION("crypto", "\
 			crypto.c \


### PR DESCRIPTION
As of OpenSSL 1.1.0, library names have changed. This fixes configure for Windows builds for OpenSSL 1.1.0, which is used by default on PHP 7.2+.