### PR TITLE
PHP 8.0 support

### DIFF
--- a/crypto_base64.c
+++ b/crypto_base64.c
@@ -86,6 +86,9 @@ ZEND_BEGIN_ARG_INFO(arginfo_crypto_base64_data, 0)
 ZEND_ARG_INFO(0, data)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_crypto_base64_no_args, 0)
+ZEND_END_ARG_INFO()
+
 static const zend_function_entry php_crypto_base64_object_methods[] = {
 	PHP_CRYPTO_ME(
 		Base64, encode,
@@ -99,7 +102,7 @@ static const zend_function_entry php_crypto_base64_object_methods[] = {
 	)
 	PHP_CRYPTO_ME(
 		Base64, __construct,
-		NULL,
+		arginfo_crypto_base64_no_args,
 		ZEND_ACC_CTOR|ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
@@ -109,7 +112,7 @@ static const zend_function_entry php_crypto_base64_object_methods[] = {
 	)
 	PHP_CRYPTO_ME(
 		Base64, encodeFinish,
-		NULL,
+		arginfo_crypto_base64_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
@@ -119,7 +122,7 @@ static const zend_function_entry php_crypto_base64_object_methods[] = {
 	)
 	PHP_CRYPTO_ME(
 		Base64, decodeFinish,
-		NULL,
+		arginfo_crypto_base64_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHPC_FE_END

--- a/crypto_cipher.c
+++ b/crypto_cipher.c
@@ -209,6 +209,8 @@ ZEND_ARG_INFO(0, key)
 ZEND_ARG_INFO(0, iv)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_crypto_cipher_no_args, 0)
+ZEND_END_ARG_INFO()
 
 static const zend_function_entry php_crypto_cipher_object_methods[] = {
 	PHP_CRYPTO_ME(
@@ -238,7 +240,7 @@ static const zend_function_entry php_crypto_cipher_object_methods[] = {
 	)
 	PHP_CRYPTO_ME(
 		Cipher, getAlgorithmName,
-		NULL,
+		arginfo_crypto_cipher_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
@@ -253,7 +255,7 @@ static const zend_function_entry php_crypto_cipher_object_methods[] = {
 	)
 	PHP_CRYPTO_ME(
 		Cipher, encryptFinish,
-		NULL,
+		arginfo_crypto_cipher_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
@@ -273,7 +275,7 @@ static const zend_function_entry php_crypto_cipher_object_methods[] = {
 	)
 	PHP_CRYPTO_ME(
 		Cipher, decryptFinish,
-		NULL,
+		arginfo_crypto_cipher_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
@@ -283,27 +285,27 @@ static const zend_function_entry php_crypto_cipher_object_methods[] = {
 	)
 	PHP_CRYPTO_ME(
 		Cipher, getBlockSize,
-		NULL,
+		arginfo_crypto_cipher_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
 		Cipher, getKeyLength,
-		NULL,
+		arginfo_crypto_cipher_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
 		Cipher, getIVLength,
-		NULL,
+		arginfo_crypto_cipher_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
 		Cipher, getMode,
-		NULL,
+		arginfo_crypto_cipher_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
 		Cipher, getTag,
-		NULL,
+		arginfo_crypto_cipher_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(

--- a/crypto_cipher.c
+++ b/crypto_cipher.c
@@ -515,7 +515,7 @@ static inline void php_crypto_cipher_set_algorithm_name(zval *object,
 		char *algorithm, phpc_str_size_t algorithm_len TSRMLS_DC)
 {
 	php_strtoupper(algorithm, algorithm_len);
-	zend_update_property_stringl(php_crypto_cipher_ce, object,
+	zend_update_property_stringl(php_crypto_cipher_ce, PHPC_OBJ_FOR_PROP(object),
 			"algorithm", sizeof("algorithm")-1, algorithm, algorithm_len TSRMLS_CC);
 }
 /* }}} */

--- a/crypto_hash.c
+++ b/crypto_hash.c
@@ -371,7 +371,7 @@ static inline void php_crypto_hash_set_algorithm_name(zval *object,
 		char *algorithm, phpc_str_size_t algorithm_len TSRMLS_DC)
 {
 	php_strtoupper(algorithm, algorithm_len);
-	zend_update_property_stringl(php_crypto_hash_ce, object,
+	zend_update_property_stringl(php_crypto_hash_ce, PHPC_OBJ_FOR_PROP(object),
 			"algorithm", sizeof("algorithm")-1, algorithm, algorithm_len TSRMLS_CC);
 }
 /* }}} */

--- a/crypto_hash.c
+++ b/crypto_hash.c
@@ -122,6 +122,9 @@ ZEND_ARG_INFO(0, name)
 ZEND_ARG_INFO(0, arguments)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_crypto_hash_no_args, 0)
+ZEND_END_ARG_INFO()
+
 static const zend_function_entry php_crypto_hash_object_methods[] = {
 	PHP_CRYPTO_ME(
 		Hash, getAlgorithms,
@@ -150,27 +153,27 @@ static const zend_function_entry php_crypto_hash_object_methods[] = {
 	)
 	PHP_CRYPTO_ME(
 		Hash, getAlgorithmName,
-		NULL,
+		arginfo_crypto_hash_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
 		Hash, digest,
-		NULL,
+		arginfo_crypto_hash_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
 		Hash, hexdigest,
-		NULL,
+		arginfo_crypto_hash_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
 		Hash, getSize,
-		NULL,
+		arginfo_crypto_hash_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
 		Hash, getBlockSize,
-		NULL,
+		arginfo_crypto_hash_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHPC_FE_END

--- a/crypto_kdf.c
+++ b/crypto_kdf.c
@@ -76,6 +76,9 @@ ZEND_BEGIN_ARG_INFO(arginfo_crypto_kdf_salt, 0)
 ZEND_ARG_INFO(0, salt)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_crypto_kdf_no_args, 0)
+ZEND_END_ARG_INFO()
+
 static const zend_function_entry php_crypto_kdf_object_methods[] = {
 	PHP_CRYPTO_ME(
 		KDF, __construct,
@@ -88,7 +91,7 @@ static const zend_function_entry php_crypto_kdf_object_methods[] = {
 	)
 	PHP_CRYPTO_ME(
 		KDF, getLength,
-		NULL,
+		arginfo_crypto_kdf_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
@@ -98,7 +101,7 @@ static const zend_function_entry php_crypto_kdf_object_methods[] = {
 	)
 	PHP_CRYPTO_ME(
 		KDF, getSalt,
-		NULL,
+		arginfo_crypto_kdf_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
@@ -139,7 +142,7 @@ static const zend_function_entry php_crypto_pbkdf2_object_methods[] = {
 	)
 	PHP_CRYPTO_ME(
 		PBKDF2, getIterations,
-		NULL,
+		arginfo_crypto_kdf_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(
@@ -149,7 +152,7 @@ static const zend_function_entry php_crypto_pbkdf2_object_methods[] = {
 	)
 	PHP_CRYPTO_ME(
 		PBKDF2, getHashAlgorithm,
-		NULL,
+		arginfo_crypto_kdf_no_args,
 		ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(

--- a/crypto_object.c
+++ b/crypto_object.c
@@ -35,7 +35,7 @@ static void php_crypto_object_do_all(const OBJ_NAME *name, void *arg)
 {
 	php_crypto_object_do_all_param *pp = (php_crypto_object_do_all_param *) arg;
 	if ((pp->aliases || name->alias == 0) &&
-			(!pp->prefix || !strncmp(name->name, pp->prefix, pp->prefix_len))) {
+			(!pp->prefix || !strncasecmp(name->name, pp->prefix, pp->prefix_len))) {
 		PHPC_ARRAY_ADD_NEXT_INDEX_CSTR(pp->return_value, (char *) name->name);
 	}
 }

--- a/crypto_rand.c
+++ b/crypto_rand.c
@@ -64,6 +64,9 @@ ZEND_BEGIN_ARG_INFO(arginfo_crypto_rand_write_file, 0)
 ZEND_ARG_INFO(0, filename)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_crypto_rand_no_args, 0)
+ZEND_END_ARG_INFO()
+
 static const zend_function_entry php_crypto_rand_object_methods[] = {
 	PHP_CRYPTO_ME(
 		Rand, generate,
@@ -77,7 +80,7 @@ static const zend_function_entry php_crypto_rand_object_methods[] = {
 	)
 	PHP_CRYPTO_ME(
 		Rand, cleanup,
-		NULL,
+		arginfo_crypto_rand_no_args,
 		ZEND_ACC_STATIC|ZEND_ACC_PUBLIC
 	)
 	PHP_CRYPTO_ME(

--- a/tests/stream_file_plain_open.phpt
+++ b/tests/stream_file_plain_open.phpt
@@ -21,6 +21,6 @@ if (file_exists($filename))
 ?>
 --EXPECTF--
 
-Warning: fopen(crypto.file://%s): failed to open stream: operation failed in %s on line %d
+Warning: fopen(crypto.file://%s): %cailed to open stream: operation failed in %s on line %d
 resource(%d) of type (stream)
 bool(true)

--- a/tests/stream_filters_cipher_ccm_error.phpt
+++ b/tests/stream_filters_cipher_ccm_error.phpt
@@ -46,5 +46,5 @@ if (file_exists($filename))
 --EXPECTF--
 Warning: fopen(): The CCM mode is not supported in stream in %s on line %d
 
-Warning: %s failed to open stream: operation failed in %s on line %d
+Warning: %s %cailed to open stream: operation failed in %s on line %d
 NOT SUPPORTED


### PR DESCRIPTION
The extent of my testing this is currently only just making sure all the tests pass when run in debug mode (--enable-debug).

There are 2 failing tests on my machine which I attribute to changes in OpenSSL (the tests are too brittle).

The third commit fixes a bug introduced by use with newer versions of OpenSSL (the algorithm name cases are now lowercased). I can separate this into another PR if desired.