### PR TITLE
Fixed UB in stream wrapper

### DIFF
--- a/crypto_stream.c
+++ b/crypto_stream.c
@@ -544,6 +544,8 @@ static php_stream *php_crypto_stream_opener(php_stream_wrapper *wrapper,
 	if (self->bio == NULL) {
 		goto opener_error_on_bio_init;
 	}
+	self->auth_enc = 0;
+	self->is_encrypting = 0;
 
 	if (PHPC_STREAM_CONTEXT_GET_OPTION_IN_COND(context,
 			PHP_CRYPTO_STREAM_WRAPPER_NAME, "filters", ppv_filter)) {


### PR DESCRIPTION
The following error (and other similar errors in a handful of other tests) show up with `USE_ZEND_ALLOC=0` and `valgrind`:
```
==152176== Memcheck, a memory error detector
==152176== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==152176== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==152176== Command: sapi/cli/php ext/php-crypto/tests/stream_file_plain_seek.phpt
==152176== 
==152176== Conditional jump or move depends on uninitialised value(s)
==152176==    at 0x48006C: php_crypto_stream_read (crypto_stream.c:267)
==152176==    by 0x60D3CC: _php_stream_fill_read_buffer (streams.c:666)
==152176==    by 0x60D588: _php_stream_read (streams.c:718)
==152176==    by 0x60D706: php_stream_read_to_str (streams.c:764)
==152176==    by 0x541889: zif_fread (file.c:1745)
==152176==    by 0x6DDFC1: ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER (zend_vm_execute.h:1295)
==152176==    by 0x756048: execute_ex (zend_vm_execute.h:54528)
==152176==    by 0x75B8B3: zend_execute (zend_vm_execute.h:58875)
==152176==    by 0x6A2AF0: zend_execute_scripts (zend.c:1680)
==152176==    by 0x5EB02D: php_execute_script (main.c:2488)
==152176==    by 0x79FCC1: do_cli (php_cli.c:949)
==152176==    by 0x7A0ED9: main (php_cli.c:1336)
==152176==  Uninitialised value was created by a heap allocation
==152176==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==152176==    by 0x6625C1: __zend_malloc (zend_alloc.c:3030)
==152176==    by 0x661018: _malloc_custom (zend_alloc.c:2418)
==152176==    by 0x6611D9: _emalloc (zend_alloc.c:2537)
==152176==    by 0x480C92: php_crypto_stream_opener (crypto_stream.c:542)
==152176==    by 0x611246: _php_stream_open_wrapper_ex (streams.c:2122)
==152176==    by 0x53B426: zif_fopen (file.c:887)
==152176==    by 0x6DDFC1: ZEND_DO_ICALL_SPEC_RETVAL_USED_HANDLER (zend_vm_execute.h:1295)
==152176==    by 0x756048: execute_ex (zend_vm_execute.h:54528)
==152176==    by 0x75B8B3: zend_execute (zend_vm_execute.h:58875)
==152176==    by 0x6A2AF0: zend_execute_scripts (zend.c:1680)
==152176==    by 0x5EB02D: php_execute_script (main.c:2488)
==152176== 
==152176== 
==152176== HEAP SUMMARY:
==152176==     in use at exit: 0 bytes in 0 blocks
==152176==   total heap usage: 15,416 allocs, 15,416 frees, 2,394,060 bytes allocated
==152176== 
==152176== All heap blocks were freed -- no leaks are possible
==152176== 
==152176== For lists of detected and suppressed errors, rerun with: -s
==152176== ERROR SUMMARY: 2 errors from 1 contexts (suppressed: 0 from 0)
```

This happens because [this](https://github.com/bukka/php-crypto/blob/5f26ac91b0ba96742cc6284cd00f8db69c3788b2/crypto_stream.c#L423) is never executed in some cases, and it's not initialized anywhere else.