### PR TITLE
Setup GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: PHP ${{ matrix.php }}, ZTS=${{ matrix.zts }}
+    runs-on: ubuntu-20.04
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - 7.1.33
+          - 7.2.34
+          - 7.3.26
+          - 7.4.14
+        zts: [on, off]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Restore PHP build cache
+        id: php-build-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/php
+          key: php-build-${{ matrix.php }}-zts-${{ matrix.zts }}
+
+      - name: Clone php-build/php-build
+        if: steps.php-build-cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: php-build/php-build
+          path: ${{ github.workspace }}/php-build
+
+      - name: Compile PHP
+        if: steps.php-build-cache.outputs.cache-hit != 'true'
+        run: |
+          cd ${{ github.workspace }}/php-build
+          ./install-dependencies.sh
+          PHP_BUILD_ZTS_ENABLE=${{ matrix.zts }} ./bin/php-build ${{ matrix.php }} ${{ github.workspace}}/php
+
+      - name: Install extension
+        run: |
+          cd ${{ github.workspace }}
+          ${{ github.workspace }}/php/bin/phpize
+          ./configure --with-php-config=${{ github.workspace }}/php/bin/php-config
+          make -j8 install
+          echo "extension=crypto.so" > ${{ github.workspace }}/php/etc/conf.d/crypto.ini
+
+      - name: Run PHPT tests
+        run: |
+          cd ${{ github.workspace }}
+          REPORT_EXIT_STATUS=1 NO_INTERACTION=1 TEST_PHP_ARGS='--show-diff' make test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,9 @@ jobs:
         php:
           - 7.1.33
           - 7.2.34
-          - 7.3.26
-          - 7.4.14
+          - 7.3.27
+          - 7.4.15
+          - 8.0.2
         zts: [on, off]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I found this useful in the time I spent working on 8.0, so maybe it will be useful upstream too.

This builds and tests the extension on PHP 7.1-8.0 on Ubuntu 20.04. It uses https://github.com/php-build/php-build to build PHP for testing.
7.0 and below are not tested because it turned out to be a pain in the ass to get 7.0 and below to build, and I figured it wasn't worth the hassle since 7.0 and below are EOL in any case.

The test runs show test failures because of changes in behaviour in OpenSSL 1.1+ which the tests don't account for.
See here for a demonstration: https://github.com/pmmp/php-crypto/runs/1848991852?check_suite_focus=true