### PR TITLE
Set minimal OpenSSL version to 1.1.1 and PHP to 5.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .deps
 *.lo
 *.la
+*.dep
 Makefile*
 acinclude.m4
 aclocal.m4

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,5 +2,12 @@
 
 List of all features for the release
 
+## 0.4.0
+- Set minimal OpenSSL version to 1.1.1
+- Set minimal PHP version to 5.6
+
+## 0.3.2
+- Fixed compatibility with PHP 8
+
 ## 0.3.1
 - Fixed segfault on PHP 5 in setting KDF key length and PBKDF2 iterations

--- a/README.md
+++ b/README.md
@@ -9,13 +9,10 @@ The php-crypto is an objective wrapper for OpenSSL Crypto library.
 
 Before starting with installation of this extensions, the `OpenSSL` library
 has to be installed. It is defaultly installed on the most Linux distributions.
-The minimal version of OpenSSL that is supported is 0.9.8 but it is recommended
-to have installed version 1.0.1+ to use all features. 
+The minimal version of OpenSSL that is supported is 1.1.1.
 
 Of course PHP has to be installed too. The minimal version that is supported is
-5.3 as the extension uses namespaces. Currently PHP also needs to be compiled
-with OpenSSL extension (`--with-openssl`). This dependency will be removed
-in the future.
+5.6 as the extension uses namespaces.
 
 #### Fedora
 

--- a/TODO.md
+++ b/TODO.md
@@ -48,7 +48,7 @@
   - It's just for PHP 5 (no memleak in 7)
 
 ## KDF
-- Add support for scrypt (OpenSSL 1.1 only)
+- Add support for scrypt
   - EVP_PBE_scrypt
 - Add support HKDF
 
@@ -80,17 +80,12 @@
   - At least 1.0.1 should be used
 
 ## General
-- Consider shorter prefix than `php_crypto`
-  - `pce` (Php Crypto Extension)
-  - `pcw` (Php Crypto Wrapper)
-  - `pcg` (Php CryptoGraphy)
-  - `pct` (Php CrypTo or later maybe Php Crypto Tls)
-  - `pcr` (Php CRypto)
+- Add generic API deprecation support
 - Clear OpenSSL errors
   - Separate OpenSSL emitted errors and PHP Crypto extenstion errors
 - Add file for utility functions
   - Containing `{prefix}_strtoupper_dup` for algorithm name conversion
-- Add Travis support
+- Improve GitHub CI version to run on older PHP version if they will be kept
 - Improve overflow handling
   - try inline the functions (make sure it works on Travis)
   - test all overflow checks on PHP 7 (skip PHP 5) 32 and 64 bit
@@ -103,5 +98,4 @@
 ## 0.4.0 (devel)
 - Added verification function for Hash
 - Added open_basedir check for Rand::loadFile and Rand::writeFile
-- Drop support for OpenSSL 0.9.8
 

--- a/config.m4
+++ b/config.m4
@@ -1,35 +1,46 @@
-dnl $Id$
 dnl config.m4 for extension crypto
 
 PHP_ARG_WITH(crypto, for crypto support,
 [  --with-crypto             Include crypto support])
 
 if test "$PHP_CRYPTO" != "no"; then
-  test -z "$PHP_OPENSSL" && PHP_OPENSSL=no
-  if test "$PHP_OPENSSL" != "no" || test "$PHP_OPENSSL_DIR" != "no"; then
-    dnl Try to find pkg-config
-    if test -z "$PKG_CONFIG"; then
-      AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
-    fi
-    dnl If pkg-config is found try using it
-    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists openssl; then
+  dnl Try to find pkg-config
+  if test -z "$PKG_CONFIG"; then
+    AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+  fi
+  dnl If pkg-config is found try using it
+  if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists openssl; then
+    OPENSSL_VERSION=`$PKG_CONFIG --modversion openssl`
+    case "$OPENSSL_VERSION" in
+      1.1.1*|3*|4*|5*)
+        found_crypto_openssl=yes
+        ;;
+      *)
+        found_crypto_openssl=no
+        ;;
+    esac
+    if test "$found_crypto_openssl" = "yes"; then
       OPENSSL_INCDIR=`$PKG_CONFIG --variable=includedir openssl`
       PHP_ADD_INCLUDE($OPENSSL_INCDIR)
       CRYPTO_LIBS=`$PKG_CONFIG --libs openssl`
       PHP_EVAL_LIBLINE($CRYPTO_LIBS, CRYPTO_SHARED_LIBADD)
-    fi
 
-    AC_DEFINE(HAVE_CRYPTOLIB,1,[Enable objective OpenSSL Crypto wrapper])
-    PHP_SUBST(CRYPTO_SHARED_LIBADD)
-    PHP_NEW_EXTENSION(crypto, 
-      crypto.c \
-	  crypto_object.c \
-	  crypto_cipher.c \
-	  crypto_hash.c \
-	  crypto_kdf.c \
-      crypto_base64.c \
-      crypto_stream.c \
-      crypto_rand.c,
-      $ext_shared)
+      AC_DEFINE(HAVE_CRYPTOLIB,1,[Enable objective OpenSSL Crypto wrapper])
+      PHP_SUBST(CRYPTO_SHARED_LIBADD)
+      PHP_NEW_EXTENSION(crypto, 
+        crypto.c \
+        crypto_object.c \
+        crypto_cipher.c \
+        crypto_hash.c \
+        crypto_kdf.c \
+        crypto_base64.c \
+        crypto_stream.c \
+        crypto_rand.c,
+        $ext_shared)
+    else
+      AC_MSG_ERROR([The minimal OpenSSL version is 1.1.1 - found $OPENSSL_VERSION])
+    fi
+  else
+    AC_MSG_ERROR([OpenSSL pkgconfig not found])
   fi
 fi

--- a/crypto.c
+++ b/crypto.c
@@ -178,11 +178,11 @@ PHP_CRYPTO_API void php_crypto_verror(const php_crypto_error_info *info, zend_cl
 	}
 	switch (action) {
 		case PHP_CRYPTO_ERROR_ACTION_ERROR:
-			php_verror(NULL, "", ei->level, PHP_CRYPTO_GET_ERROR_MESSAGE(ei->msg, message), args TSRMLS_CC);
+			php_verror(NULL, "", ei->level, ei->msg, args TSRMLS_CC);
 			break;
 		case PHP_CRYPTO_ERROR_ACTION_EXCEPTION:
 			if (ignore_args) {
-				zend_throw_exception(exc_ce, PHP_CRYPTO_GET_ERROR_MESSAGE(ei->msg, message), code TSRMLS_CC);
+				zend_throw_exception(exc_ce, ei->msg, code TSRMLS_CC);
 			} else {
 				vspprintf(&message, 0, ei->msg, args);
 				zend_throw_exception(exc_ce, message, code TSRMLS_CC);

--- a/crypto_base64.c
+++ b/crypto_base64.c
@@ -23,37 +23,6 @@
 
 #include <openssl/evp.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-
-static inline EVP_ENCODE_CTX *EVP_ENCODE_CTX_new()
-{
-	EVP_ENCODE_CTX *ctx = OPENSSL_malloc(sizeof(EVP_ENCODE_CTX));
-
-	return ctx;
-}
-
-static inline void EVP_ENCODE_CTX_free(EVP_ENCODE_CTX *ctx)
-{
-	OPENSSL_free(ctx);
-}
-
-static inline int EVP_ENCODE_CTX_copy(EVP_ENCODE_CTX *dctx, EVP_ENCODE_CTX *sctx)
-{
-	memcpy(dctx, sctx, sizeof (EVP_ENCODE_CTX));
-
-	return 1;
-}
-
-static inline int EVP_ENCODE_CTX_num(EVP_ENCODE_CTX *ctx)
-{
-	return ctx->num;
-}
-
-#define EVP_ENCODE_LENGTH(l) (((l+2)/3*4)+(l/48+1)*2+80)
-#define EVP_DECODE_LENGTH(l) ((l+3)/4*3+80)
-
-#endif
-
 PHP_CRYPTO_EXCEPTION_DEFINE(Base64)
 PHP_CRYPTO_ERROR_INFO_BEGIN(Base64)
 PHP_CRYPTO_ERROR_INFO_ENTRY(

--- a/crypto_cipher.c
+++ b/crypto_cipher.c
@@ -446,28 +446,9 @@ PHPC_OBJ_HANDLER_CLONE(crypto_cipher)
 				PHP_CRYPTO_CIPHER_AAD_LEN(PHPC_THIS);
 	}
 
-#ifdef PHP_CRYPTO_HAS_CIPHER_CTX_COPY
 	copy_success = EVP_CIPHER_CTX_copy(
 			PHP_CRYPTO_CIPHER_CTX(PHPC_THAT),
 			PHP_CRYPTO_CIPHER_CTX(PHPC_THIS));
-#else
-	memcpy(PHP_CRYPTO_CIPHER_CTX(PHPC_THAT),
-			PHP_CRYPTO_CIPHER_CTX(PHPC_THIS),
-			sizeof *(PHP_CRYPTO_CIPHER_CTX(PHPC_THAT)));
-
-	copy_success = 1;
-	if (PHP_CRYPTO_CIPHER_CTX(PHPC_THIS)->cipher_data &&
-			PHP_CRYPTO_CIPHER_CTX(PHPC_THIS)->cipher->ctx_size) {
-		PHP_CRYPTO_CIPHER_CTX(PHPC_THAT)->cipher_data = OPENSSL_malloc(
-				PHP_CRYPTO_CIPHER_CTX(PHPC_THIS)->cipher->ctx_size);
-		if (!PHP_CRYPTO_CIPHER_CTX(PHPC_THAT)->cipher_data) {
-			copy_success = 0;
-		}
-		memcpy(PHP_CRYPTO_CIPHER_CTX(PHPC_THAT)->cipher_data,
-				PHP_CRYPTO_CIPHER_CTX(PHPC_THIS)->cipher_data,
-				PHP_CRYPTO_CIPHER_CTX(PHPC_THIS)->cipher->ctx_size);
-	}
-#endif
 
 	PHP_CRYPTO_CIPHER_ALG(PHPC_THAT) = EVP_CIPHER_CTX_cipher(PHP_CRYPTO_CIPHER_CTX(PHPC_THIS));
 

--- a/crypto_kdf.c
+++ b/crypto_kdf.c
@@ -112,8 +112,6 @@ static const zend_function_entry php_crypto_kdf_object_methods[] = {
 	PHPC_FE_END
 };
 
-#ifdef PHP_CRYPTO_HAS_PBKDF2
-
 ZEND_BEGIN_ARG_INFO_EX(arginfo_crypto_pbkdf2_new, 0, 0, 2)
 ZEND_ARG_INFO(0, hashAlgorithm)
 ZEND_ARG_INFO(0, length)
@@ -162,8 +160,6 @@ static const zend_function_entry php_crypto_pbkdf2_object_methods[] = {
 	)
 	PHPC_FE_END
 };
-
-#endif
 
 PHP_CRYPTO_API zend_class_entry *php_crypto_kdf_ce;
 PHP_CRYPTO_API zend_class_entry *php_crypto_pbkdf2_ce;
@@ -255,7 +251,6 @@ PHP_MINIT_FUNCTION(crypto_kdf)
 	PHP_CRYPTO_EXCEPTION_REGISTER(ce, KDF);
 	PHP_CRYPTO_ERROR_INFO_REGISTER(KDF);
 
-#ifdef PHP_CRYPTO_HAS_PBKDF2
 	/* PBKDF2 class */
 	INIT_CLASS_ENTRY(ce, PHP_CRYPTO_CLASS_NAME(PBKDF2), php_crypto_pbkdf2_object_methods);
 	php_crypto_pbkdf2_ce = PHPC_CLASS_REGISTER_EX(ce, php_crypto_kdf_ce, NULL);
@@ -263,7 +258,6 @@ PHP_MINIT_FUNCTION(crypto_kdf)
 	/* PBKDF2 Exception registration */
 	PHP_CRYPTO_EXCEPTION_REGISTER_EX(ce, PBKDF2, KDF);
 	PHP_CRYPTO_ERROR_INFO_REGISTER(PBKDF2);
-#endif
 
 	return SUCCESS;
 }
@@ -362,8 +356,7 @@ PHP_CRYPTO_METHOD(KDF, setLength)
 	PHPC_THIS_DECLARE(crypto_kdf);
 	phpc_long_t key_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l",
-			&key_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &key_len) == FAILURE) {
 		return;
 	}
 	PHPC_THIS_FETCH(crypto_kdf);
@@ -409,7 +402,6 @@ PHP_CRYPTO_METHOD(KDF, setSalt)
 }
 /* }}} */
 
-#ifdef PHP_CRYPTO_HAS_PBKDF2
 /* PBKDF2 methods */
 
 /* {{{ php_crypto_pbkdf2_set_hash_algorithm */
@@ -573,4 +565,3 @@ PHP_CRYPTO_METHOD(PBKDF2, setHashAlgorithm)
 	RETURN_BOOL(php_crypto_pbkdf2_set_hash_algorithm(PHPC_THIS, hash_alg TSRMLS_CC) == SUCCESS);
 }
 /* }}} */
-#endif

--- a/crypto_rand.c
+++ b/crypto_rand.c
@@ -127,7 +127,7 @@ PHP_CRYPTO_METHOD(Rand, generate)
 	int num;
 	PHPC_STR_DECLARE(buf);
 	zval *zstrong_result = NULL;
-	zend_bool strong_result, must_be_strong = 1;
+	zend_bool must_be_strong = 1;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|bz/",
 				&num_long, &must_be_strong, &zstrong_result) == FAILURE) {
@@ -142,22 +142,13 @@ PHP_CRYPTO_METHOD(Rand, generate)
 
 	PHPC_STR_ALLOC(buf, num);
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	if (must_be_strong) {
-#endif
-		if (!RAND_bytes((unsigned char *) PHPC_STR_VAL(buf), num)) {
-			php_crypto_error(PHP_CRYPTO_ERROR_ARGS(Rand, GENERATE_PREDICTABLE));
-			PHPC_STR_RELEASE(buf);
-			RETURN_FALSE;
-		}
-		strong_result = 1;
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	} else {
-		strong_result = RAND_pseudo_bytes((unsigned char *) PHPC_STR_VAL(buf), num);
+	if (!RAND_bytes((unsigned char *) PHPC_STR_VAL(buf), num)) {
+		php_crypto_error(PHP_CRYPTO_ERROR_ARGS(Rand, GENERATE_PREDICTABLE));
+		PHPC_STR_RELEASE(buf);
+		RETURN_FALSE;
 	}
-#endif
 	if (zstrong_result) {
-		ZVAL_BOOL(zstrong_result, strong_result);
+		ZVAL_BOOL(zstrong_result, 1);
 	}
 	PHPC_STR_VAL(buf)[num] = '\0';
 	PHPC_STR_RETURN(buf);

--- a/package.xml
+++ b/package.xml
@@ -179,7 +179,7 @@
  <dependencies>
   <required>
    <php>
-    <min>5.3.2</min>
+    <min>5.6.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0a1</min>

--- a/php_crypto.h
+++ b/php_crypto.h
@@ -212,33 +212,6 @@ PHP_MSHUTDOWN_FUNCTION(crypto);
 PHP_MINFO_FUNCTION(crypto);
 
 
-/* COMPATIBILITY */
-
-#define PHP_CRYPTO_COPY_ERROR_MESSAGE \
-	(PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION == 5 && PHP_RELEASE_VERSION >= 5) \
-	|| (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION >= 6) \
-	|| (PHP_MAJOR_VERSION > 5)
-
-#if PHP_CRYPTO_COPY_ERROR_MESSAGE
-#define PHP_CRYPTO_GET_ERROR_MESSAGE(const_msg, tmp_msg) \
-	(const_msg)
-#else
-#define PHP_CRYPTO_GET_ERROR_MESSAGE(const_msg, tmp_msg) \
-	(tmp_msg = estrdup(const_msg))
-#endif
-
-/* OpenSSL features test */
-#if OPENSSL_VERSION_NUMBER >= 0x10001000L
-#define PHP_CRYPTO_HAS_CMAC 1
-#endif
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-#define PHP_CRYPTO_HAS_CIPHER_CTX_COPY 1
-#endif
-
-#define PHP_CRYPTO_ADD_CCM_ALGOS \
-	!defined(OPENSSL_NO_AES) && defined(EVP_CIPH_CCM_MODE) \
-		&& OPENSSL_VERSION_NUMBER < 0x100020000
-
 #endif	/* PHP_CRYPTO_H */
 
 /*

--- a/php_crypto_hash.h
+++ b/php_crypto_hash.h
@@ -24,9 +24,7 @@
 
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
-#ifdef PHP_CRYPTO_HAS_CMAC
 #include <openssl/cmac.h>
-#endif
 
 typedef enum {
 	PHP_CRYPTO_HASH_TYPE_NONE,
@@ -45,26 +43,20 @@ PHPC_OBJ_STRUCT_BEGIN(crypto_hash)
 	php_crypto_hash_status status;
 	union {
 		const EVP_MD *md;
-#ifdef PHP_CRYPTO_HAS_CMAC
 		const EVP_CIPHER *cipher;
-#endif
 	} alg;
 	union {
 		EVP_MD_CTX *md;
 		HMAC_CTX *hmac;
-#ifdef PHP_CRYPTO_HAS_CMAC
 		CMAC_CTX *cmac;
-#endif
 	} ctx;
 	char *key;
 	int key_len;
 PHPC_OBJ_STRUCT_END()
 
 /* Hash or MAC object accessors */
-#ifdef PHP_CRYPTO_HAS_CMAC
 #define PHP_CRYPTO_CMAC_CTX(pobj) (pobj)->ctx.cmac
 #define PHP_CRYPTO_CMAC_ALG(pobj) (pobj)->alg.cipher
-#endif
 #define PHP_CRYPTO_HASH_CTX(pobj) (pobj)->ctx.md
 #define PHP_CRYPTO_HASH_ALG(pobj) (pobj)->alg.md
 #define PHP_CRYPTO_HMAC_CTX(pobj) (pobj)->ctx.hmac
@@ -82,9 +74,7 @@ PHP_CRYPTO_ERROR_INFO_EXPORT(MAC)
 /* Class entries */
 extern PHP_CRYPTO_API zend_class_entry *php_crypto_hash_ce;
 extern PHP_CRYPTO_API zend_class_entry *php_crypto_hmac_ce;
-#ifdef PHP_CRYPTO_HAS_CMAC
 extern PHP_CRYPTO_API zend_class_entry *php_crypto_cmac_ce;
-#endif
 
 /* USER METHODS */
 

--- a/php_crypto_kdf.h
+++ b/php_crypto_kdf.h
@@ -22,11 +22,6 @@
 #include "php.h"
 #include "php_crypto.h"
 
-/* PBKDF2 feature test */
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-#define PHP_CRYPTO_HAS_PBKDF2 1
-#endif
-
 typedef enum {
 	PHP_CRYPTO_KDF_TYPE_NONE,
 	PHP_CRYPTO_KDF_TYPE_PBKDF2
@@ -73,7 +68,6 @@ PHP_CRYPTO_METHOD(KDF, setLength);
 PHP_CRYPTO_METHOD(KDF, getSalt);
 PHP_CRYPTO_METHOD(KDF, setSalt);
 
-#ifdef PHP_CRYPTO_HAS_PBKDF2
 /* PBKDF2 methods */
 PHP_CRYPTO_METHOD(PBKDF2, __construct);
 PHP_CRYPTO_METHOD(PBKDF2, derive);
@@ -81,7 +75,6 @@ PHP_CRYPTO_METHOD(PBKDF2, getIterations);
 PHP_CRYPTO_METHOD(PBKDF2, setIterations);
 PHP_CRYPTO_METHOD(PBKDF2, getHashAlgorithm);
 PHP_CRYPTO_METHOD(PBKDF2, setHashAlgorithm);
-#endif
 
 #endif	/* PHP_CRYPTO_KDF_H */
 


### PR DESCRIPTION
This drops support for OpenSSL versions that made development a bit harder. It means that the only supported version is OpenSSL 1.1.1. Also PHP min version has been bumped to 5.6. I might bump it more if there's a need for it but for now it's 5.6 as it just works.