### PR TITLE
fix for PHP 8.4

### DIFF
--- a/crypto.c
+++ b/crypto.c
@@ -76,7 +76,11 @@ PHP_MINIT_FUNCTION(crypto)
 	zend_class_entry ce;
 
 	/* Register base exception */
+#if PHP_VERSION_ID < 70000
 	PHP_CRYPTO_EXCEPTION_REGISTER_CE(ce, Crypto, zend_exception_get_default(TSRMLS_C));
+#else
+	PHP_CRYPTO_EXCEPTION_REGISTER_CE(ce, Crypto, zend_ce_exception);
+#endif
 
 	/* Init OpenSSL algorithms */
 	OpenSSL_add_all_algorithms();

--- a/crypto_cipher.c
+++ b/crypto_cipher.c
@@ -497,7 +497,7 @@ PHP_MINIT_FUNCTION(crypto_cipher)
 static inline void php_crypto_cipher_set_algorithm_name(zval *object,
 		char *algorithm, phpc_str_size_t algorithm_len TSRMLS_DC)
 {
-#if PHP_VERSION_ID < 80400
+#if PHP_VERSION_ID < 80200
 	php_strtoupper(algorithm, algorithm_len);
 #else
 	zend_str_toupper(algorithm, algorithm_len);
@@ -517,18 +517,14 @@ PHP_CRYPTO_API const EVP_CIPHER *php_crypto_get_cipher_algorithm(
 		return NULL;
 	}
 
-#if PHP_VERSION_ID < 80400
+#if PHP_VERSION_ID < 80200
 	php_strtoupper(algorithm, algorithm_len);
 #else
 	zend_str_toupper(algorithm, algorithm_len);
 #endif
 	cipher = EVP_get_cipherbyname(algorithm);
 	if (!cipher) {
-#if PHP_VERSION_ID < 80400
-		php_strtolower(algorithm, algorithm_len);
-#else
 		zend_str_tolower(algorithm, algorithm_len);
-#endif
 		cipher = EVP_get_cipherbyname(algorithm);
 	}
 	return cipher;

--- a/crypto_cipher.c
+++ b/crypto_cipher.c
@@ -497,7 +497,11 @@ PHP_MINIT_FUNCTION(crypto_cipher)
 static inline void php_crypto_cipher_set_algorithm_name(zval *object,
 		char *algorithm, phpc_str_size_t algorithm_len TSRMLS_DC)
 {
+#if PHP_VERSION_ID < 80400
 	php_strtoupper(algorithm, algorithm_len);
+#else
+	zend_str_toupper(algorithm, algorithm_len);
+#endif
 	zend_update_property_stringl(php_crypto_cipher_ce, PHPC_OBJ_FOR_PROP(object),
 			"algorithm", sizeof("algorithm")-1, algorithm, algorithm_len TSRMLS_CC);
 }
@@ -513,10 +517,18 @@ PHP_CRYPTO_API const EVP_CIPHER *php_crypto_get_cipher_algorithm(
 		return NULL;
 	}
 
+#if PHP_VERSION_ID < 80400
 	php_strtoupper(algorithm, algorithm_len);
+#else
+	zend_str_toupper(algorithm, algorithm_len);
+#endif
 	cipher = EVP_get_cipherbyname(algorithm);
 	if (!cipher) {
+#if PHP_VERSION_ID < 80400
 		php_strtolower(algorithm, algorithm_len);
+#else
+		zend_str_tolower(algorithm, algorithm_len);
+#endif
 		cipher = EVP_get_cipherbyname(algorithm);
 	}
 	return cipher;

--- a/crypto_hash.c
+++ b/crypto_hash.c
@@ -319,7 +319,7 @@ PHP_MINIT_FUNCTION(crypto_hash)
 static inline void php_crypto_hash_set_algorithm_name(zval *object,
 		char *algorithm, phpc_str_size_t algorithm_len TSRMLS_DC)
 {
-#if PHP_VERSION_ID < 80400
+#if PHP_VERSION_ID < 80200
 	php_strtoupper(algorithm, algorithm_len);
 #else
 	zend_str_toupper(algorithm, algorithm_len);

--- a/crypto_hash.c
+++ b/crypto_hash.c
@@ -319,7 +319,11 @@ PHP_MINIT_FUNCTION(crypto_hash)
 static inline void php_crypto_hash_set_algorithm_name(zval *object,
 		char *algorithm, phpc_str_size_t algorithm_len TSRMLS_DC)
 {
+#if PHP_VERSION_ID < 80400
 	php_strtoupper(algorithm, algorithm_len);
+#else
+	zend_str_toupper(algorithm, algorithm_len);
+#endif
 	zend_update_property_stringl(php_crypto_hash_ce, PHPC_OBJ_FOR_PROP(object),
 			"algorithm", sizeof("algorithm")-1, algorithm, algorithm_len TSRMLS_CC);
 }


### PR DESCRIPTION
From UPGRADING.INTERNALS
```
   - The php_strtoupper(), php_string_toupper(), php_strtolower(), and
     php_string_tolower() functions has been removed, use zend_str_toupper(),
     zend_string_toupper(), zend_str_tolower(), and zend_string_tolower()
     respectively instead.

```